### PR TITLE
Read webuild url from environment variable

### DIFF
--- a/video_uploader/app/services/webuild_scraper_service.rb
+++ b/video_uploader/app/services/webuild_scraper_service.rb
@@ -2,7 +2,7 @@ require 'faraday'
 
 class WebuildScraperService
   def scrape
-    response = Faraday.get 'https://webuild.sg/api/v1/events'
+    response = Faraday.get ENV['WEBUILDSG_EVENT_URL'] || 'https://webuild.sg/api/v1/events'
     sessions = JSON.parse(response.body, symbolize_names: true)
 
     sessions[:events].collect do |session|


### PR DESCRIPTION
Please use: http://api-webuild.7e14.starter-us-west-2.openshiftapps.com/events
The format matches the current webuild events api and at some point we'll migrate it over: https://webuild.sg/api/v1/events